### PR TITLE
Fix building on macOS and Android CI

### DIFF
--- a/depends/common/bnes/0001-Fix-building-on-macOS.patch
+++ b/depends/common/bnes/0001-Fix-building-on-macOS.patch
@@ -1,0 +1,84 @@
+From ef980714002bc124a706b8626b1b263d6e961997 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Sun, 11 Aug 2024 20:35:18 -0700
+Subject: [PATCH 1/2] Fix building on macOS
+
+Errors were:
+
+  ./nall/bit.hpp:29:3: error: unknown type name 'constexpr'
+    constexpr inline uintmax_t mask(const char* s, uintmax_t sum = 0) {
+    ^
+
+  ./nall/file.hpp:168:21: error: variable has incomplete type 'struct stat64'
+        struct stat64 data;
+                      ^
+
+  libco/aarch64.c:15:10: fatal error: 'malloc.h' file not found
+  #include <malloc.h>
+           ^~~~~~~~~~
+---
+ Makefile        |  3 ++-
+ libco/aarch64.c |  2 +-
+ nall/file.hpp   | 12 ++++++++++++
+ 3 files changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 4b0c268..a0d1d0c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -5,6 +5,7 @@ TARGET_NAME := BNES
+ ifeq ($(platform),osx)
+    fpic := -fPIC
+    TARGET := bnes_libretro.dylib
++   flags += -DHAVE_POSIX_MEMALIGN
+ else ifneq (,$(findstring ios,$(platform)))
+    fpic := -fPIC
+    TARGET := bnes_libretro_ios.dylib
+@@ -104,7 +105,7 @@ ifeq ($(platform),ios-arm64)
+    cpp := $(CXX) -std=c++11 -stdlib=libc++ #-std=gnu++0x
+ else
+    c := $(CC) -std=gnu99
+-   cpp := $(CXX) #-std=gnu++0x
++   cpp := $(CXX) -std=gnu++0x
+ endif
+ 
+ flags += $(opt) -fomit-frame-pointer -fno-tree-vectorize -I. $(fpic)
+diff --git a/libco/aarch64.c b/libco/aarch64.c
+index 3c3b2f8..1a88ab9 100644
+--- a/libco/aarch64.c
++++ b/libco/aarch64.c
+@@ -11,7 +11,7 @@
+ #include <string.h>
+ #include <stdint.h>
+ 
+-#ifndef IOS
++#if !defined(IOS) && !defined(__APPLE__)
+ #include <malloc.h>
+ #endif
+ 
+diff --git a/nall/file.hpp b/nall/file.hpp
+index 5b4f4d1..fdc0d35 100644
+--- a/nall/file.hpp
++++ b/nall/file.hpp
+@@ -1,6 +1,18 @@
+ #ifndef NALL_FILE_HPP
+ #define NALL_FILE_HPP
+ 
++#if defined(_WIN32)
++#include <sys/types.h>
++#include <sys/stat.h>
++#define stat64 _stat64
++#elif defined(__APPLE__) || defined(__MACH__)
++#include <sys/types.h>
++#include <sys/stat.h>
++#define stat64 stat
++#elif defined(__linux__)
++#include <sys/stat.h>
++#endif
++
+ #include <nall/platform.hpp>
+ #include <nall/stdint.hpp>
+ #include <nall/string.hpp>
+-- 
+2.34.1
+

--- a/depends/common/bnes/0002-Fix-building-on-Android.patch
+++ b/depends/common/bnes/0002-Fix-building-on-Android.patch
@@ -1,0 +1,90 @@
+From c11d92f2044166c10c425887a031961fd91dd699 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Sun, 11 Aug 2024 21:17:40 -0700
+Subject: [PATCH 2/2] Fix building on Android
+
+Error was:
+
+  nes/nes.hpp:47:11: error: reference to 'uint_t' is ambiguous
+    typedef uint_t< 5> uint5;
+            ^
+---
+ nes/nes.hpp | 58 ++++++++++++++++++++++++++---------------------------
+ 1 file changed, 29 insertions(+), 29 deletions(-)
+
+diff --git a/nes/nes.hpp b/nes/nes.hpp
+index ed76f85..a365ff7 100644
+--- a/nes/nes.hpp
++++ b/nes/nes.hpp
+@@ -40,39 +40,39 @@ namespace NES {
+   typedef int32_t int32;
+   typedef int64_t int64;
+ 
+-  typedef uint_t< 1> uint1;
+-  typedef uint_t< 2> uint2;
+-  typedef uint_t< 3> uint3;
+-  typedef uint_t< 4> uint4;
+-  typedef uint_t< 5> uint5;
+-  typedef uint_t< 6> uint6;
+-  typedef uint_t< 7> uint7;
++  typedef nall::uint_t< 1> uint1;
++  typedef nall::uint_t< 2> uint2;
++  typedef nall::uint_t< 3> uint3;
++  typedef nall::uint_t< 4> uint4;
++  typedef nall::uint_t< 5> uint5;
++  typedef nall::uint_t< 6> uint6;
++  typedef nall::uint_t< 7> uint7;
+   typedef uint8_t    uint8;
+ 
+-  typedef uint_t< 9> uint9;
+-  typedef uint_t<10> uint10;
+-  typedef uint_t<11> uint11;
+-  typedef uint_t<12> uint12;
+-  typedef uint_t<13> uint13;
+-  typedef uint_t<14> uint14;
+-  typedef uint_t<15> uint15;
++  typedef nall::uint_t< 9> uint9;
++  typedef nall::uint_t<10> uint10;
++  typedef nall::uint_t<11> uint11;
++  typedef nall::uint_t<12> uint12;
++  typedef nall::uint_t<13> uint13;
++  typedef nall::uint_t<14> uint14;
++  typedef nall::uint_t<15> uint15;
+   typedef uint16_t   uint16;
+ 
+-  typedef uint_t<17> uint17;
+-  typedef uint_t<18> uint18;
+-  typedef uint_t<19> uint19;
+-  typedef uint_t<20> uint20;
+-  typedef uint_t<21> uint21;
+-  typedef uint_t<22> uint22;
+-  typedef uint_t<23> uint23;
+-  typedef uint_t<24> uint24;
+-  typedef uint_t<25> uint25;
+-  typedef uint_t<26> uint26;
+-  typedef uint_t<27> uint27;
+-  typedef uint_t<28> uint28;
+-  typedef uint_t<29> uint29;
+-  typedef uint_t<30> uint30;
+-  typedef uint_t<31> uint31;
++  typedef nall::uint_t<17> uint17;
++  typedef nall::uint_t<18> uint18;
++  typedef nall::uint_t<19> uint19;
++  typedef nall::uint_t<20> uint20;
++  typedef nall::uint_t<21> uint21;
++  typedef nall::uint_t<22> uint22;
++  typedef nall::uint_t<23> uint23;
++  typedef nall::uint_t<24> uint24;
++  typedef nall::uint_t<25> uint25;
++  typedef nall::uint_t<26> uint26;
++  typedef nall::uint_t<27> uint27;
++  typedef nall::uint_t<28> uint28;
++  typedef nall::uint_t<29> uint29;
++  typedef nall::uint_t<30> uint30;
++  typedef nall::uint_t<31> uint31;
+   typedef uint32_t   uint32;
+ 
+   typedef uint64_t   uint64;
+-- 
+2.34.1
+


### PR DESCRIPTION
## Description

Currently, Android and macOS are failing to build on Jenkins. This PR imports two patches that allow the builds to succeed.

## How has this been tested?

Before:

macOS errors:

```
  ./nall/bit.hpp:29:3: error: unknown type name 'constexpr'
    constexpr inline uintmax_t mask(const char* s, uintmax_t sum = 0) {
    ^

  ./nall/file.hpp:168:21: error: variable has incomplete type 'struct stat64'
        struct stat64 data;
                      ^

  libco/aarch64.c:15:10: fatal error: 'malloc.h' file not found
  #include <malloc.h>
           ^~~~~~~~~~
```

Android error:

```
  nes/nes.hpp:47:11: error: reference to 'uint_t' is ambiguous
    typedef uint_t< 5> uint5;
            ^
```

After:

Builds succeed: https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro.bnes/detail/PR-7/1/